### PR TITLE
Added environment/tbi-cluster.sh as workflow environment.

### DIFF
--- a/resources/analysisTools/copyNumberEstimationWorkflow/environments/tbi-cluster.sh
+++ b/resources/analysisTools/copyNumberEstimationWorkflow/environments/tbi-cluster.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright (c) 2017 The ACEseq workflow developers.
+# Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/ACEseqWorkflow/LICENSE.txt).
+# Load a Conda environment.
+
+module load "htslib/$HTSLIB_VERSION"
+export BGZIP_BINARY=bgzip
+export TABIX_BINARY=tabix
+
+module load "perl/$PERL_VERSION"
+export PERL_BINARY=perl
+
+module load "python/$PYTHON_VERSION"
+export PYTHON_BINARY=python
+
+module load "R/$RSCRIPT_VERSION"
+export RSCRIPT_BINARY=Rscript
+
+module load "bedtools/$BEDTOOLS_VERSION"
+export INTERSECTBED_BINARY=intersectBed
+
+module load "vcftools/$VCFTOOLS_VERSION"
+export VCFTOOLS_SORT_BINARY=vcf-sort
+
+module load "samtools/$SAMTOOLS_VERSION"
+export BCFTOOLS_BINARY=bcftools
+export SAMTOOLS_BINARY=samtools

--- a/resources/configurationFiles/analysisCopyNumberEstimation.xml
+++ b/resources/configurationFiles/analysisCopyNumberEstimation.xml
@@ -218,6 +218,7 @@
              "workflow_environment_${environmentTool}". -->
         <tool name="workflowEnvironment_condaTbiPbs" value="conda_tbi-pbs-cluster.sh" basepath="copyNumberEstimationWorkflow/environments"/>
         <tool name="workflowEnvironment_conda" value="conda.sh" basepath="copyNumberEstimationWorkflow/environments"/>
+        <tool name="workflowEnvironment_tbiCluster" value="tbi-cluster.sh" basepath="copyNumberEstimationWorkflow/environments"/>
 
         <!-- Cluster-job specific environments.
              Tool-specific environments override the global workflows environment. You can reference the tool name


### PR DESCRIPTION
This allows running the ACEseq worflow natively on the now LSF cluster with the same software versions as on the old PBS cluster.